### PR TITLE
Flush fix

### DIFF
--- a/hand_evaluations.py
+++ b/hand_evaluations.py
@@ -43,8 +43,7 @@ def isFlush(hand):
     for suit in suits:
         if len(np.intersect1d(hand, suit)) == 5:
             return True
-        else:
-            return False
+    return False
     
 def isStraight(hand):
     #convert list of card values to numbers/faces

--- a/hand_evaluations.py
+++ b/hand_evaluations.py
@@ -41,7 +41,7 @@ def isFlush(hand):
 
     #check both players' hands for flushes
     for suit in suits:
-        if len(np.intersect1d(hand, suit)) == 5:
+        if len(np.intersect1d(hand, suit)) >= 5:
             return True
     return False
     


### PR DESCRIPTION
The `isFlush` function had a bug. It prematurely exited the function when the first flush check was `false`. The correct behavior is to check all 4 suits before saying it is not a flush. 

Another bug was it only accepted a flush of 5 cards. But since we merge the hole cards with the board cards a flush of 6 or 7 cards should still count.